### PR TITLE
Integrate with plutus-starter template

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,15 @@
+Merge plutus-starter with SIDAN;
+
+Test with:
+
+```
+git clone https://github.com/SIDANWhatever/plutus-cborhex-automation.git
+cd plutus-cborhex-automation/
+nix-shell
+cd example
+cabal run sidan-plutus-server
+```
+
+Observe: 
+
+> Spock is running on port 8080


### PR DESCRIPTION
Why?

- [plutus-starter](https://github.com/input-output-hk/plutus-starter) provides CI pipeline to run tests on a remote server; 
- [good doc](https://github.com/input-output-hk/plutus-starter/blob/main/CONTRIBUTING.md) on updating dependencies in plutus-apps
- provides nix scaffolding necessary to build deployment artifacts.
